### PR TITLE
Correct and simplify build process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Dependency Installation
     
 Generate documentation with `yuidoc .`.
 
-Run unit tests with `grunt test`.
+Just run unit tests with `grunt test`.  `npm test` will also install dependencies.
 
 Lint with `grunt jshint`.
 
-Debug with `grunt serve`.
+Just debug with `grunt serve`.  `npm start` will also install dependencies.
 
 Build for production or deployment with `grunt build`.
 

--- a/app/index.html
+++ b/app/index.html
@@ -24,19 +24,20 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>iArtNorfolk</title>
 
-        <!-- build:css styles/main.css -->
         <link rel="stylesheet" href="bower_components/pure/pure-min.css">
+
+        <!-- build:css styles/main.css -->
         <link rel="stylesheet" href="styles/normalize.css">
         <link rel="stylesheet" href="styles/style.css">
         <link rel="stylesheet" href="styles/leaflet.css">
-        <!-- build:css styles/main.css -->
+        <!-- endbuild -->
+
         <!--[if lte IE 8]>
         <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/grids-responsive-old-ie-min.css">
         <![endif]-->
         <!--[if gt IE 8]><!-->
         <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/grids-responsive-min.css">
         <!--<![endif]-->
-        <!-- endbuild -->
     </head>
 
     <body>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "start": "npm install && bower install && grunt serve",
-    "test": "npm install && bower install && cd test && bower install && cd .. && grunt test"
+    "test": "npm install && bower install && cd test && bower install && cd .. && grunt jshint test"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "type": "git",
     "url": "https://github.com/Code4HR/norfolkart.git"
   },
+  "scripts": {
+    "start": "npm install && bower install && grunt serve",
+    "test": "npm install && bower install && cd test && bower install && cd .. && grunt test"
+  },
   "dependencies": {},
   "devDependencies": {
     "connect-livereload": "~0.2.0",


### PR DESCRIPTION
Define npm start and test scripts to alleviate development process.  Include linting into testing process as a requirement for basic style guideline checking.  Update the readme to reflect these changes.  Correct stylesheet minification wrappers, since it caused build errors that caused funky visual artefacts.